### PR TITLE
Add Docker for development environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,15 @@ TODO:
 * Provide an admin UI for configuring the Okta org and client ID/secret
 * Clean up the UX around installing the plugin, like making sure the admin user can still log in after the plugin is activated
 * Handle errors better (or at all really)
+
+## Development Environment
+
+### Manual
+
+Install WordPress and move plugin to wp-content/plugins directory
+
+### Docker
+
+Install Docker and docker-compose and run `docker-compose up` 
+
+Navigate to http://localhost:8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3.1'
+
+services:
+  wordpress:
+    image: wordpress
+    depends_on:
+      - mysql
+    ports:
+      - 8080:80
+    environment:
+      WORDPRESS_DB_PASSWORD: password
+    volumes:
+      - .:/var/www/html/wp-content/plugins/okta-wordpress-sign-in-widget
+
+  mysql:
+    image: mysql:5.7
+    environment:
+      MYSQL_ROOT_PASSWORD: password


### PR DESCRIPTION
Hello Aaron,

This pull request adds support for spinning up the development environment using docker. It makes setting up the development environment very simple for new developers.

I have pre-configured docker-compose to automatically:

1. Create a WordPress container and MySQL container.
2. Configure WordPress to connect to MySQL.
3. Install the Okta Sign In Widget using the local filesystem by mounting the volume onto the WordPress plugins directory.

So, as a developer who already has Docker and docker composer, getting started with development on this WordPress plugin takes seconds: `docker-compose up`.

Regards,
Omar Chehab