### PR TITLE
Pass two arguments to wp_login action as expected

### DIFF
--- a/okta-widget.php
+++ b/okta-widget.php
@@ -212,7 +212,7 @@ class OktaSignIn
 
         // See also: https://developer.wordpress.org/reference/functions/do_action/
         // Run the wp_login actions now that the user is logged in
-        do_action('wp_login', $user->user_login);
+        do_action('wp_login', $user->user_login, $user);
 
         if (isset($_SESSION['redirect_to'])) {
             $redirect_uri = $_SESSION['redirect_to'];


### PR DESCRIPTION
wp_login action hook expects two argments but only one passed.
Pass required `$user` argument also alongwith `$user_login`.
See: https://developer.wordpress.org/reference/hooks/wp_login/

Fix #11.