### PR TITLE
Before login action and token scope filter

### DIFF
--- a/okta-widget.php
+++ b/okta-widget.php
@@ -183,12 +183,14 @@ class OktaSignIn
             die("Okta reports that id_token is not active or client authentication failed:" . $claims['error_description']);
         }
         /********************************************/
-
-        $this->logUserIntoWordPressFromEmail($claims['email'], $redirect_to);
+        
+        $this->logUserIntoWordPressFromEmail($claims, $redirect_to);
     }
 
-    private function logUserIntoWordPressFromEmail($email, $redirect_to)
+    private function logUserIntoWordPressFromEmail($claims, $redirect_to)
     {
+        $email = $claims['email'];
+
         // Find or create the WordPress user for this email address
         $user = get_user_by('email', $email);
         if (!$user) {
@@ -198,6 +200,8 @@ class OktaSignIn
         } else {
             $user_id = $user->ID;
         }
+
+        do_action('okta_widget_before_login', $claims, $user);
 
         // Actually log the user in now
         wp_set_current_user($user_id);

--- a/templates/sign-in-form.php
+++ b/templates/sign-in-form.php
@@ -70,7 +70,7 @@
             clientId: '<?php echo get_option('okta-widget-client-id') ?>',
             getAccessToken: false,
             getIdToken: true,
-            scope: 'openid email'
+            scope: '<?php echo apply_filters( 'okta_widget_token_scope', 'openid email') ?>'
         });
     }
 </script>


### PR DESCRIPTION
Thanks for developing and releasing this plugin! We've been putting it to use and wanted to share back two customizations to it we've made for our purposes.

This PR adds two new hooks to the plugin:

1. An action called `okta_widget_before_login`
2. A filter called `okta_widget_token_scope`

We are using the action `okta_widget_before_login` in our own custom plugin to store some of the claims as user meta to personalize the site.

We are using the filter `okta_widget_token_scope` in our own custom plugin to request the profile scope to obtain and store the user's last name on the initial login.