### PR TITLE
added read_and_close option to session_start

### DIFF
--- a/okta-widget.php
+++ b/okta-widget.php
@@ -70,7 +70,10 @@ class OktaSignIn
     public function startSessionAction()
     {
         if (session_status() != PHP_SESSION_ACTIVE) {
-            session_start();
+            session_start([
+                    'read_and_close' => true,
+                ]
+            );
         }
     }
 


### PR DESCRIPTION
Resolves WP Site Health error check.  PHP's session_start -> read_and_close option described here: https://www.php.net/manual/en/function.session-start.php 